### PR TITLE
Feature/static velocity

### DIFF
--- a/LegendOfCube/LegendOfCube/Engine/EventSystem.cs
+++ b/LegendOfCube/LegendOfCube/Engine/EventSystem.cs
@@ -10,6 +10,56 @@ namespace LegendOfCube.Engine
 {
 	class EventSystem
 	{
+		private const float ON_GROUND_LIMIT = 0.70f;
+		private const float ON_WALL_LIMIT = 0.90f;
+
+		public static void CalculateCubeState(World world)
+		{
+			// Defaults to not being on the ground or on the wall
+			world.PlayerCubeState.OnGround = false;
+			world.PlayerCubeState.OnWall = false;
+			world.PlayerCubeState.GroundAxis = Vector3.Zero;
+			world.PlayerCubeState.WallAxis = Vector3.Zero;
+
+			// Check if player cube collided with any walls or grounds
+			foreach (var e in world.EventBuffer.CollisionEvents)
+			{
+				if (e.Collider.Id == world.Player.Id)
+				{
+					if (Math.Abs(e.Axis.Y) > ON_GROUND_LIMIT)
+					{
+						world.PlayerCubeState.OnGround = true;
+						world.PlayerCubeState.GroundAxis = e.Axis;
+					}
+					else if ((Math.Abs(e.Axis.X) + Math.Abs(e.Axis.Z)) > ON_WALL_LIMIT)
+					{
+						world.PlayerCubeState.OnWall = true;
+						world.PlayerCubeState.WallAxis = e.Axis;
+					}
+				}
+				else if (e.CollidedWith.Id == world.Player.Id)
+				{
+					if (Math.Abs(e.Axis.Y) > ON_GROUND_LIMIT)
+					{
+						world.PlayerCubeState.OnGround = true;
+						world.PlayerCubeState.GroundAxis = -e.Axis;
+					}
+					else if ((Math.Abs(e.Axis.X) + Math.Abs(e.Axis.Z)) > ON_WALL_LIMIT)
+					{
+						world.PlayerCubeState.OnWall = true;
+						world.PlayerCubeState.WallAxis = -e.Axis;
+					}
+				}
+			}
+
+			// If Cube is on the ground it can't be on a wall.
+			if (world.PlayerCubeState.OnGround)
+			{
+				world.PlayerCubeState.OnWall = false;
+				world.PlayerCubeState.WallAxis = Vector3.Zero;
+			}
+		}
+
 		public static void HandleEvents(World world)
 		{
 			EventBuffer eventBuffer = world.EventBuffer;
@@ -63,7 +113,6 @@ namespace LegendOfCube.Engine
 			//{
 			//	world.PlayerCubeState.InAir = true;
 			//
-			world.EventBuffer.Flush();
 		}
 	}
 }

--- a/LegendOfCube/LegendOfCube/Engine/EventSystem.cs
+++ b/LegendOfCube/LegendOfCube/Engine/EventSystem.cs
@@ -5,13 +5,15 @@ using System.Security.Policy;
 using System.Text;
 using LegendOfCube.Engine.Events;
 using Microsoft.Xna.Framework;
+using System.Diagnostics;
 
 namespace LegendOfCube.Engine
 {
 	class EventSystem
 	{
-		private const float ON_GROUND_LIMIT = 0.70f;
-		private const float ON_WALL_LIMIT = 0.90f;
+		private static readonly float GROUND_WALL_ANGLE = MathHelper.ToRadians(75.0f); // 0 < angle < 90
+		private static readonly float ON_WALL_LIMIT = (float)Math.Sin(GROUND_WALL_ANGLE);
+		private static readonly float ON_GROUND_LIMIT = (float)Math.Cos(GROUND_WALL_ANGLE);
 
 		public static void CalculateCubeState(World world)
 		{
@@ -24,30 +26,20 @@ namespace LegendOfCube.Engine
 			// Check if player cube collided with any walls or grounds
 			foreach (var e in world.EventBuffer.CollisionEvents)
 			{
-				if (e.Collider.Id == world.Player.Id)
+				float xDot = Math.Abs(e.Axis.X);
+				float zDot = Math.Abs(e.Axis.Z);
+				float wallDot = (float)Math.Sqrt(xDot * xDot + zDot * zDot);
+				if (e.Collider.Id == world.Player.Id || e.CollidedWith.Id == world.Player.Id)
 				{
-					if (Math.Abs(e.Axis.Y) > ON_GROUND_LIMIT)
+					if (e.Axis.Y > ON_GROUND_LIMIT)
 					{
 						world.PlayerCubeState.OnGround = true;
-						world.PlayerCubeState.GroundAxis = e.Axis;
+						world.PlayerCubeState.GroundAxis = (e.Collider.Id == world.Player.Id ? 1.0f : -1.0f) * e.Axis;
 					}
-					else if ((Math.Abs(e.Axis.X) + Math.Abs(e.Axis.Z)) > ON_WALL_LIMIT)
+					else if (wallDot > ON_WALL_LIMIT)
 					{
 						world.PlayerCubeState.OnWall = true;
-						world.PlayerCubeState.WallAxis = e.Axis;
-					}
-				}
-				else if (e.CollidedWith.Id == world.Player.Id)
-				{
-					if (Math.Abs(e.Axis.Y) > ON_GROUND_LIMIT)
-					{
-						world.PlayerCubeState.OnGround = true;
-						world.PlayerCubeState.GroundAxis = -e.Axis;
-					}
-					else if ((Math.Abs(e.Axis.X) + Math.Abs(e.Axis.Z)) > ON_WALL_LIMIT)
-					{
-						world.PlayerCubeState.OnWall = true;
-						world.PlayerCubeState.WallAxis = -e.Axis;
+						world.PlayerCubeState.WallAxis = (e.Collider.Id == world.Player.Id ? 1.0f : -1.0f) * e.Axis;
 					}
 				}
 			}

--- a/LegendOfCube/LegendOfCube/Engine/GameScreen.cs
+++ b/LegendOfCube/LegendOfCube/Engine/GameScreen.cs
@@ -40,8 +40,9 @@ namespace LegendOfCube.Engine
 			AI_system.Update(World, delta);
 			gameplaySystem.ProcessInputData(World, delta);
 			physicsSystem.ApplyPhysics(delta, World); // Note, delta should be fixed time step.
-			cameraSystem.OnUpdate(World, delta);
+			EventSystem.CalculateCubeState(World);
 			EventSystem.HandleEvents(World);
+			cameraSystem.OnUpdate(World, delta);
 		}
 
 		protected internal override void Draw(GameTime gameTime, RenderSystem renderSystem)

--- a/LegendOfCube/LegendOfCube/Engine/PhysicsSystem.cs
+++ b/LegendOfCube/LegendOfCube/Engine/PhysicsSystem.cs
@@ -152,28 +152,7 @@ namespace LegendOfCube.Engine
 				world.EventBuffer.AddEvent(ref ce);
 
 				// Collision response part 1: Rotate OBB.
-				OBBAxis colAxisEnum = worldSpaceOBBs[i].ClosestAxisEnum(ref axis);
-				switch (colAxisEnum)
-				{
-					case OBBAxis.X_PLUS:
-					case OBBAxis.X_MINUS:
-						worldSpaceOBBs[i].AxisX = colAxisEnum.Sign() * axis;
-						worldSpaceOBBs[i].AxisY = Vector3.Cross(worldSpaceOBBs[i].AxisZ, worldSpaceOBBs[i].AxisX);
-						worldSpaceOBBs[i].AxisZ = Vector3.Cross(worldSpaceOBBs[i].AxisX, worldSpaceOBBs[i].AxisY);
-						break;
-					case OBBAxis.Y_PLUS:
-					case OBBAxis.Y_MINUS:
-						worldSpaceOBBs[i].AxisY = colAxisEnum.Sign() * axis;
-						worldSpaceOBBs[i].AxisX = Vector3.Cross(worldSpaceOBBs[i].AxisY, worldSpaceOBBs[i].AxisZ);
-						worldSpaceOBBs[i].AxisZ = Vector3.Cross(worldSpaceOBBs[i].AxisX, worldSpaceOBBs[i].AxisY);
-						break;
-					case OBBAxis.Z_PLUS:
-					case OBBAxis.Z_MINUS:
-						worldSpaceOBBs[i].AxisZ = colAxisEnum.Sign() * axis;
-						worldSpaceOBBs[i].AxisX = Vector3.Cross(worldSpaceOBBs[i].AxisY, worldSpaceOBBs[i].AxisZ);
-						worldSpaceOBBs[i].AxisY = Vector3.Cross(worldSpaceOBBs[i].AxisZ, worldSpaceOBBs[i].AxisX);
-						break;
-				}
+				RotateOBB(ref worldSpaceOBBs[i], ref axis);
 
 				// Move OBB to collision point
 				worldSpaceOBBs[i].Position -= diff;
@@ -247,18 +226,12 @@ namespace LegendOfCube.Engine
 				world.PlayerCubeState = tempCubeState;
 			}
 
-			// Update translation in transform
-			Vector3 obbDiff = worldSpaceOBBs[i].Position - oldObb.Position;
-			world.Transforms[i].Translation += obbDiff;
-			// Update rotation: This is probably a really stupid way.
-			world.Transforms[i].Forward = worldSpaceOBBs[i].AxisZ * world.Transforms[i].Forward.Length();
-			world.Transforms[i].Left = worldSpaceOBBs[i].AxisX * world.Transforms[i].Left.Length();
-			world.Transforms[i].Up = worldSpaceOBBs[i].AxisY * world.Transforms[i].Up.Length();
+			TransformFromOBBs(ref oldObb, ref worldSpaceOBBs[i], ref world.Transforms[i]);
 		}
 
 		private void MoveStaticWithCollisionChecking(World world, UInt32 i, float delta)
 		{
-			MoveDynamicWithCollisionChecking(world, i, delta);
+			
 		}
 
 		private void MoveWithoutCollisionChecking(World world, UInt32 i, float delta)
@@ -334,6 +307,43 @@ namespace LegendOfCube.Engine
 
 			float timeUntilCol = FindTimeUntilIntersection(ref target, ref collider, -axisOut * accumulatedStep, 1.0f, 4);
 			collider.Position += (timeUntilCol * accumulatedStep * -axisOut);
+		}
+
+		private void RotateOBB(ref OBB obbOut, ref Vector3 axis)
+		{
+			OBBAxis colAxisEnum = obbOut.ClosestAxisEnum(ref axis);
+			switch (colAxisEnum)
+			{
+				case OBBAxis.X_PLUS:
+				case OBBAxis.X_MINUS:
+					obbOut.AxisX = colAxisEnum.Sign() * axis;
+					obbOut.AxisY = Vector3.Cross(obbOut.AxisZ, obbOut.AxisX);
+					obbOut.AxisZ = Vector3.Cross(obbOut.AxisX, obbOut.AxisY);
+					break;
+				case OBBAxis.Y_PLUS:
+				case OBBAxis.Y_MINUS:
+					obbOut.AxisY = colAxisEnum.Sign() * axis;
+					obbOut.AxisX = Vector3.Cross(obbOut.AxisY, obbOut.AxisZ);
+					obbOut.AxisZ = Vector3.Cross(obbOut.AxisX, obbOut.AxisY);
+					break;
+				case OBBAxis.Z_PLUS:
+				case OBBAxis.Z_MINUS:
+					obbOut.AxisZ = colAxisEnum.Sign() * axis;
+					obbOut.AxisX = Vector3.Cross(obbOut.AxisY, obbOut.AxisZ);
+					obbOut.AxisY = Vector3.Cross(obbOut.AxisZ, obbOut.AxisX);
+					break;
+			}
+		}
+
+		private void TransformFromOBBs(ref OBB oldOBB, ref OBB newOBB, ref Matrix transformOut)
+		{
+			// Update translation in transform
+			Vector3 obbDiff = newOBB.Position - oldOBB.Position;
+			transformOut.Translation += obbDiff;
+			// Update rotation: This is probably a really stupid way.
+			transformOut.Forward = newOBB.AxisZ * transformOut.Forward.Length();
+			transformOut.Left = newOBB.AxisX * transformOut.Left.Length();
+			transformOut.Up = newOBB.AxisY * transformOut.Up.Length();
 		}
 	}
 }

--- a/LegendOfCube/LegendOfCube/Engine/PhysicsSystem.cs
+++ b/LegendOfCube/LegendOfCube/Engine/PhysicsSystem.cs
@@ -50,14 +50,7 @@ namespace LegendOfCube.Engine
 				// Moving
 				if (world.EntityProperties[i].Satisfies(Properties.TRANSFORM | Properties.VELOCITY | Properties.MODEL_SPACE_BV | Properties.DYNAMIC_VELOCITY_FLAG))
 				{
-					if (i == world.Player.Id)
-					{
-						MovePlayerCube(world, i, delta);
-					}
-					else
-					{
-						MoveDynamicWithCollisionChecking(world, i, delta);
-					}	
+					MoveDynamicWithCollisionChecking(world, i, delta);
 				}
 				else if (world.EntityProperties[i].Satisfies(Properties.TRANSFORM | Properties.VELOCITY | Properties.MODEL_SPACE_BV))
 				{
@@ -110,11 +103,6 @@ namespace LegendOfCube.Engine
 			{
 				world.Velocities[i] += (world.Gravity * delta);
 			}
-		}
-
-		private void MovePlayerCube(World world, UInt32 i, float delta)
-		{
-			MoveDynamicWithCollisionChecking(world, i, delta);
 		}
 		
 		private void MoveDynamicWithCollisionChecking(World world, UInt32 i, float delta)

--- a/LegendOfCube/LegendOfCube/Engine/Properties.cs
+++ b/LegendOfCube/LegendOfCube/Engine/Properties.cs
@@ -24,9 +24,10 @@ namespace LegendOfCube.Engine
 		public const UInt64 MODEL_SPACE_BV = 1 << 7;
 		public const UInt64 DEATH_ZONE_FLAG = 1 << 8;
 		public const UInt64 BOUNCE_FLAG = 1 << 9;
-		public const UInt64 AI_FLAG = 1 << 11;
 		public const UInt64 TELEPORT_FLAG = 1 << 10;
-
+		public const UInt64 AI_FLAG = 1 << 11;
+		public const UInt64 DYNAMIC_VELOCITY_FLAG = 1 << 13;
+		
 		// Members
 		// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 

--- a/LegendOfCube/LegendOfCube/Levels/ConceptLevel.cs
+++ b/LegendOfCube/LegendOfCube/Levels/ConceptLevel.cs
@@ -69,7 +69,7 @@ namespace LegendOfCube.Levels
 					.WithAcceleration(Vector3.Zero, 60)
 					.WithStandardEffectParams(playerEffect)
 					.WithBoundingVolume(new OBB(new Vector3(0, 0.5f, 0), Vector3.UnitX, Vector3.UnitY, Vector3.UnitZ, new Vector3(1, 1, 1)))
-					.WithAdditionalProperties(new Properties(Properties.INPUT_FLAG | Properties.GRAVITY_FLAG))
+					.WithAdditionalProperties(new Properties(Properties.INPUT_FLAG | Properties.GRAVITY_FLAG | Properties.DYNAMIC_VELOCITY_FLAG))
 					.AddToWorld(world);
 
 			world.Player = playerEntity;

--- a/LegendOfCube/LegendOfCube/Levels/TestLevel1.cs
+++ b/LegendOfCube/LegendOfCube/Levels/TestLevel1.cs
@@ -87,7 +87,7 @@ namespace LegendOfCube.Levels
 					.WithStandardEffectParams(playerEffect)
 					.WithBoundingVolume(new OBB(new Vector3(0, 0.5f, 0), new Vector3(1, 0, 0), new Vector3(0, 1, 0),
 						new Vector3(0, 0, 1), new Vector3(1, 1, 1)))
-					.WithAdditionalProperties(new Properties(Properties.INPUT_FLAG | Properties.GRAVITY_FLAG))
+					.WithAdditionalProperties(new Properties(Properties.INPUT_FLAG | Properties.GRAVITY_FLAG | Properties.DYNAMIC_VELOCITY_FLAG))
 					.AddToWorld(world);
 			world.Player = playerEntity;
 


### PR DESCRIPTION
Added a new property: DYNAMIC_VELOCITY_FLAG

Entities with this flag can be rotated and have their velocity changed by the PhysicsSystem. If they collide into something they will adjust, not the target. Currently only the player cube has the DYNAMIC_VELOCITY_FLAG.

If an entity doesn't have the flag they will move through other static entities and move dynamic ones.

Other changes:
- Complete OBB vs OBB intersection test
- Moved calculation of cube state out of PhysicsSystem and into EventSystem.
- Lots of cleanup in PhysicsSystem.
- Other stuff I've forgotten about.
