### PR TITLE
Control whether an entity casts or receive shadows

### DIFF
--- a/LegendOfCube/LegendOfCube/Engine/Graphics/RenderSystem.cs
+++ b/LegendOfCube/LegendOfCube/Engine/Graphics/RenderSystem.cs
@@ -19,8 +19,10 @@ namespace LegendOfCube.Engine.Graphics
 		                                                                Properties.MODEL |
 		                                                                Properties.TRANSFORM |
 		                                                                Properties.STANDARD_EFFECT);
-	
+
 		private static readonly Properties HAS_OBB = new Properties(Properties.MODEL_SPACE_BV);
+		private static readonly Properties NO_SHADOW_CAST = new Properties(Properties.NO_SHADOW_CAST_FLAG);
+		private static readonly Properties NO_SHADOW_RECEIVE = new Properties(Properties.NO_SHADOW_RECEIVE_FLAG);
 
 		private static readonly Vector4 LIGHT_COLOR = Color.White.ToVector4();
 		private const int SHADOW_MAP_SIZE = 2048;
@@ -164,7 +166,7 @@ namespace LegendOfCube.Engine.Graphics
 			RenderTargetBinding[] origRenderTargets = new RenderTargetBinding[game.GraphicsDevice.GetRenderTargets().Length];
 			game.GraphicsDevice.GetRenderTargets().CopyTo(origRenderTargets, 0);
 			game.GraphicsDevice.SetRenderTarget(renderTarget);
-			game.GraphicsDevice.Clear(Color.Black);
+			game.GraphicsDevice.Clear(Color.White);
 			standardEffect.SetShadowMapRendering(true);
 
 			// The shadow map is based on an orthographic projection that could
@@ -183,7 +185,8 @@ namespace LegendOfCube.Engine.Graphics
 
 			foreach (var entity in entities)
 			{
-				if (!world.EntityProperties[entity.Id].Satisfies(STANDARD_EFFECT_COMPATIBLE))
+				Properties properties = world.EntityProperties[entity.Id];
+				if (!properties.Satisfies(STANDARD_EFFECT_COMPATIBLE) || properties.Satisfies(NO_SHADOW_CAST))
 				{
 					continue;
 				}
@@ -313,6 +316,9 @@ namespace LegendOfCube.Engine.Graphics
 			standardEffect.SetEmissiveTexture(sep.EmissiveTexture);
 			standardEffect.SetSpecularTexture(sep.SpecularTexture);
 			standardEffect.SetNormalTexture(sep.NormalTexture);
+
+			bool noShadowReceive = world.EntityProperties[entity.Id].Satisfies(NO_SHADOW_RECEIVE);
+			standardEffect.SetApplyShadows(!noShadowReceive);
 
 			RenderModelWithStandardEffect(entity, model, transforms, ref worldTransform);
 		}

--- a/LegendOfCube/LegendOfCube/Engine/Graphics/StandardEffect.cs
+++ b/LegendOfCube/LegendOfCube/Engine/Graphics/StandardEffect.cs
@@ -28,6 +28,7 @@ namespace LegendOfCube.Engine.Graphics
 		// Lights
 		private readonly EffectParameter dirLight0ViewSpaceDirParam;
 		private readonly EffectParameter dirLight0ColorParam;
+		private readonly EffectParameter applyShadowsParam;
 		private readonly EffectParameter dirLight0ShadowMatrix0Param;
 		private readonly EffectParameter dirLight0ShadowMatrix1Param;
 
@@ -73,6 +74,7 @@ namespace LegendOfCube.Engine.Graphics
 			// Lights
 			this.dirLight0ViewSpaceDirParam = effect.Parameters["DirLight0ViewSpaceDir"];
 			this.dirLight0ColorParam = effect.Parameters["DirLight0Color"];
+			this.applyShadowsParam = effect.Parameters["ApplyShadows"];
 			this.dirLight0ShadowMatrix0Param = effect.Parameters["DirLight0ShadowMatrix0"];
 			this.dirLight0ShadowMatrix1Param = effect.Parameters["DirLight0ShadowMatrix1"];
 
@@ -147,6 +149,11 @@ namespace LegendOfCube.Engine.Graphics
 			pointLight0ViewSpacePosParam.SetValue(Vector3.Transform(position, view));
 			pointLight0ReachParam.SetValue(reach);
 			pointLight0ColorParam.SetValue(lightColor);
+		}
+
+		public void SetApplyShadows(bool applyShadows)
+		{
+			applyShadowsParam.SetValue(applyShadows);
 		}
 
 		public void SetDirLight0ShadowMap0(Texture shadowMap)

--- a/LegendOfCube/LegendOfCube/Engine/Properties.cs
+++ b/LegendOfCube/LegendOfCube/Engine/Properties.cs
@@ -29,6 +29,8 @@ namespace LegendOfCube.Engine
 		public const UInt64 CHECKPOINT_FLAG = 1 << 12;
 		public const UInt64 DYNAMIC_VELOCITY_FLAG = 1 << 13;
 		public const UInt64 WIN_ZONE_FLAG = 1 << 14;
+		public const UInt64 NO_SHADOW_CAST_FLAG = 1 << 15;
+		public const UInt64 NO_SHADOW_RECEIVE_FLAG = 1 << 16;
 		
 		// Members
 		// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *


### PR DESCRIPTION
This might be useful when building rooms for example. Then the walls might have the property `NO_SHADOW_CAST`, to let light sort of pass through, possibly with a fairly high `World.AmbientIntensity`.

There are two new properties:
- `NO_SHADOW_CAST` makes the entity not cast shadows on other objects (i.e. not included in shadow map)
- `NO_SHADOW_RECEIVE` makes the entity not receive shadows from other objects (i.e. don't check shadow maps when rendering)
