### PR TITLE
Generalized screen architecture

### DIFF
--- a/LegendOfCube/LegendOfCube/Engine/Graphics/RenderSystem.cs
+++ b/LegendOfCube/LegendOfCube/Engine/Graphics/RenderSystem.cs
@@ -58,10 +58,7 @@ namespace LegendOfCube.Engine.Graphics
 			this.graphicsManager = graphicsDeviceManager;
 		}
 
-		// Public methods
-		// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-		public void Initialize()
+		public void LoadContent()
 		{
 			this.graphicsDevice = game.GraphicsDevice;
 			obbRenderer = new OBBRenderer(graphicsDevice);
@@ -85,10 +82,7 @@ namespace LegendOfCube.Engine.Graphics
 				VertexColorEnabled = false,
 				TextureEnabled = false,
 			};
-		}
 
-		public void LoadContent()
-		{
 			this.standardEffect = StandardEffect.LoadEffect(game.Content);
 		}
 

--- a/LegendOfCube/LegendOfCube/Engine/InputSystem.cs
+++ b/LegendOfCube/LegendOfCube/Engine/InputSystem.cs
@@ -17,6 +17,7 @@ namespace LegendOfCube.Engine
 		// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
 		private Game game;
+		private ScreenSystem screenSystem;
 		private KeyboardState keyState;
 		private KeyboardState oldKeyState;
 
@@ -26,9 +27,11 @@ namespace LegendOfCube.Engine
 		// Constructors
 		// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
-		public InputSystem(Game game)
+		public InputSystem(Game game, ScreenSystem screenSystem)
 		{
 			this.game = game;
+			this.screenSystem = screenSystem;
+
 			// TODO: settings for inverted y axis
 			oldKeyState = Keyboard.GetState();
 			oldGamePadState = GamePad.GetState(PlayerIndex.One); //Assuming single player game
@@ -37,12 +40,13 @@ namespace LegendOfCube.Engine
 		// Public methods
 		// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
-		public void ApplyInput(GameTime gameTime, World world, ScreenSystem switcher)
+		public void ApplyInput(GameTime gameTime, World world)
 		{
 			keyState = Keyboard.GetState();
 			gamePadState = GamePad.GetState(PlayerIndex.One);
 			Vector2 directionInput = new Vector2(0, 0);
 
+			game.IsMouseVisible = false;
 
 			if (!gamePadState.IsConnected)
 			{
@@ -57,7 +61,7 @@ namespace LegendOfCube.Engine
 
 			if (KeyWasJustPressed(Keys.Tab) || ButtonWasJustPressed(Buttons.Start))
 			{
-				switcher.SwitchScreen(Screens.ScreenTypes.PAUSE);	
+				screenSystem.AddScreen(new PauseScreen(game, screenSystem));
 			}
 
 			if (KeyWasJustPressed(Keys.F1))

--- a/LegendOfCube/LegendOfCube/Engine/LegendOfCubeGame.cs
+++ b/LegendOfCube/LegendOfCube/Engine/LegendOfCubeGame.cs
@@ -12,7 +12,6 @@ namespace LegendOfCube.Engine
 		// Members
 		// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
-		private readonly RenderSystem renderSystem;
 		private readonly GraphicsDeviceManager graphicsManager;
 		private readonly ScreenSystem screenSystem;
 		private readonly ContentCollection contentCollection;
@@ -29,7 +28,6 @@ namespace LegendOfCube.Engine
 			graphicsManager = new GraphicsDeviceManager(this);
 			graphicsManager.PreferredBackBufferHeight = 600;
 			graphicsManager.PreferredBackBufferWidth = 800;
-			renderSystem = new RenderSystem(this, graphicsManager);
 
 			// XNA initiation moved out of RenderSystem since it's more of a "WorldRenderer"
 			// that could be disposed and reused
@@ -37,7 +35,7 @@ namespace LegendOfCube.Engine
 			graphicsManager.PreferMultiSampling = true;
 			graphicsManager.ApplyChanges();
 
-			screenSystem = new ScreenSystem(this, contentCollection);
+			screenSystem = new ScreenSystem(this, contentCollection, graphicsManager);
 
 		}
 
@@ -52,8 +50,6 @@ namespace LegendOfCube.Engine
 		/// </summary>
 		protected override void Initialize()
 		{
-			renderSystem.Initialize();
-			
 			base.Initialize();
 		}
 
@@ -64,8 +60,7 @@ namespace LegendOfCube.Engine
 		protected override void LoadContent()
 		{
 			contentCollection.LoadContent(Content);
-			renderSystem.LoadContent();
-			screenSystem.LoadAllContent();
+			screenSystem.LoadContent();
 		}
 
 		/// <summary>
@@ -84,7 +79,7 @@ namespace LegendOfCube.Engine
 		/// <param name="gameTime">Provides a snapshot of timing values.</param>
 		protected override void Update(GameTime gameTime)
 		{
-			screenSystem.GetCurrentScreen().Update(gameTime, screenSystem);
+			screenSystem.Update(gameTime);
 			base.Update(gameTime);
 		}
 
@@ -94,27 +89,11 @@ namespace LegendOfCube.Engine
 		/// <param name="gameTime">Provides a snapshot of timing values.</param>
 		protected override void Draw(GameTime gameTime)
 		{
-			screenSystem.GetCurrentScreen().Draw(gameTime, renderSystem);
+			GraphicsDevice.Clear(Color.CornflowerBlue);
+
+			screenSystem.Draw(gameTime);
 			base.Draw(gameTime);
 		}
 
-		// Helper methods
-		// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-		/*public void SwitchScreen()
-		{
-			if (currentScreen is GameScreen)
-			{
-				this.IsMouseVisible = true;
-				screens[1].SetWorld(currentScreen.World);
-				currentScreen = screens[1];
-			}
-			else if (currentScreen is PauseScreen)
-			{
-
-				this.IsMouseVisible = false;
-				currentScreen = screens[0];
-			}
-		}*/
 	}
 }

--- a/LegendOfCube/LegendOfCube/LegendOfCube.csproj
+++ b/LegendOfCube/LegendOfCube/LegendOfCube.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Levels\LevelConstants.cs" />
     <Compile Include="Screens\LevelSelectScreen.cs" />
     <Compile Include="Screens\MenuItem.cs" />
+    <Compile Include="Screens\MenuScreen.cs" />
     <Compile Include="Screens\StartScreen.cs" />
     <Compile Include="Screens\GameScreen.cs" />
     <Compile Include="Engine\MenuInputSystem.cs" />

--- a/LegendOfCube/LegendOfCube/Screens/GameScreen.cs
+++ b/LegendOfCube/LegendOfCube/Screens/GameScreen.cs
@@ -12,13 +12,19 @@ namespace LegendOfCube.Screens
 {
 	class GameScreen : Screen
 	{
+		private Level level;
+		private World world;
+
 		private InputSystem inputSystem;
 		private MovementSystem movementSystem;
 		private PhysicsSystem physicsSystem;
 		private CameraSystem cameraSystem;
 		private AISystem aiSystem;
 		private AnimationSystem animationSystem;
-		private ContentCollection contentCollection;
+		private RenderSystem renderSystem;
+
+		private readonly GraphicsDeviceManager graphicsManager;
+		private readonly ContentCollection contentCollection;
 
 		private Texture2D winScreen1;
 		private Texture2D winScreen2;
@@ -26,104 +32,108 @@ namespace LegendOfCube.Screens
 		private SpriteBatch spriteBatch;
 		private Vector2 fontPos;
 
-		public GameScreen(Game game, ContentCollection contentCollection) : base(game)
+		internal GameScreen(Level level, Game game, ScreenSystem screenSystem, ContentCollection contentCollection, GraphicsDeviceManager graphicsManager)
+			: base(game, screenSystem, true)
 		{
+			this.level = level;
 			this.contentCollection = contentCollection;
+			this.graphicsManager = graphicsManager;
 		}
 
-		protected internal override void Update(GameTime gameTime, ScreenSystem switcher)
+		internal override void Update(GameTime gameTime)
 		{
 			float delta = (float)gameTime.ElapsedGameTime.TotalSeconds;
 
 			//GameOver update
-			if (!World.WinState)
+			if (!world.WinState)
 			{
-				World.GameStats.GameTime += delta;
+				world.GameStats.GameTime += delta;
 			}
-			if (World.WinState)
+			if (world.WinState)
 			{
-				inputSystem.ApplyInput(gameTime, World, switcher);
-				physicsSystem.ApplyPhysics(World, delta);
+				inputSystem.ApplyInput(gameTime, world);
+				physicsSystem.ApplyPhysics(world, delta);
 
 				//Small delay before score screen.
-				if (World.TimeSinceGameOver < 1)
+				if (world.TimeSinceGameOver < 1)
 				{
-					World.TimeSinceGameOver += delta;
+					world.TimeSinceGameOver += delta;
 				}
 			}
 			//Normal update
 			else
 			{
-				inputSystem.ApplyInput(gameTime, World, switcher);
-				aiSystem.Update(World, delta);
-				movementSystem.ProcessInputData(World, delta);
-				physicsSystem.ApplyPhysics(World, delta); // Note, delta should be fixed time step.
-				EventSystem.CalculateCubeState(World);
-				EventSystem.HandleEvents(World);
-				animationSystem.OnUpdate(World, delta);
-				cameraSystem.OnUpdate(World, delta);
+				inputSystem.ApplyInput(gameTime, world);
+				aiSystem.Update(world, delta);
+				movementSystem.ProcessInputData(world, delta);
+				physicsSystem.ApplyPhysics(world, delta); // Note, delta should be fixed time step.
+				EventSystem.CalculateCubeState(world);
+				EventSystem.HandleEvents(world);
+				animationSystem.OnUpdate(world, delta);
+				cameraSystem.OnUpdate(world, delta);
 			}
 		}
 
-		protected internal override void Draw(GameTime gameTime, RenderSystem renderSystem)
+		internal override void Draw(GameTime gameTime)
 		{
 			Game.GraphicsDevice.Clear(Color.CornflowerBlue);
 			Game.GraphicsDevice.BlendState = BlendState.Opaque;
 			Game.GraphicsDevice.DepthStencilState = DepthStencilState.Default;
 
-			renderSystem.RenderWorld(World);
+			renderSystem.RenderWorld(world);
 
 			spriteBatch.Begin();
-			if (World.DebugState.ShowDebugOverlay)
+			if (world.DebugState.ShowDebugOverlay)
 			{
 				StringBuilder text = new StringBuilder();
 				text.Append("FPS: ");
 				text.AppendLine(UIFormat(1.0f/(float) gameTime.ElapsedGameTime.TotalSeconds));
 				text.Append("CamPos: ");
-				text.AppendLine(UIFormat(World.CameraPosition));
+				text.AppendLine(UIFormat(world.CameraPosition));
 				text.Append("CamDir: ");
-				text.AppendLine(UIFormat(Vector3.Normalize(World.Transforms[World.Player.Id].Translation - World.CameraPosition)));
+				text.AppendLine(UIFormat(Vector3.Normalize(world.Transforms[world.Player.Id].Translation - world.CameraPosition)));
 				text.Append("CubePos: ");
-				text.AppendLine(UIFormat(World.Transforms[World.Player.Id].Translation));
+				text.AppendLine(UIFormat(world.Transforms[world.Player.Id].Translation));
 				text.Append("CubeVel: ");
-				text.AppendLine(UIFormat(World.Velocities[World.Player.Id]));
+				text.AppendLine(UIFormat(world.Velocities[world.Player.Id]));
 				text.Append("CubeAcc: ");
-				text.AppendLine(UIFormat(World.Accelerations[World.Player.Id]));
+				text.AppendLine(UIFormat(world.Accelerations[world.Player.Id]));
 				text.Append("OnGround: ");
-				text.AppendLine(World.PlayerCubeState.OnGround.ToString());
+				text.AppendLine(world.PlayerCubeState.OnGround.ToString());
 				text.Append("OnWall: ");
-				text.AppendLine(World.PlayerCubeState.OnWall.ToString());
+				text.AppendLine(world.PlayerCubeState.OnWall.ToString());
 
 				spriteBatch.DrawString(font, text, fontPos, Color.DarkGreen);
 			}
 
 			//Gameover screen
-			if (World.TimeSinceGameOver >= 1 && World.WinState)
+			if (world.TimeSinceGameOver >= 1 && world.WinState)
 			{
 				spriteBatch.Draw(winScreen1, new Vector2(0, 0), Color.Red);
-				spriteBatch.DrawString(font, World.GameStats.PlayerDeaths.ToString(), new Vector2(400, 260), Color.Red);
-				spriteBatch.DrawString(font, UIFormat(World.GameStats.GameTime) + "s", new Vector2(300, 160), Color.Red);
+				spriteBatch.DrawString(font, world.GameStats.PlayerDeaths.ToString(), new Vector2(400, 260), Color.Red);
+				spriteBatch.DrawString(font, UIFormat(world.GameStats.GameTime) + "s", new Vector2(300, 160), Color.Red);
 			}
 			spriteBatch.End();
 		}
 
 		internal override void LoadContent()
 		{
-			int hardCodedLevelIndex = 0;
-			World = LevelConstants.LEVELS[hardCodedLevelIndex].CreateWorld(Game, contentCollection);
-			
+			world = level.CreateWorld(Game, contentCollection);
 
-			inputSystem = new InputSystem(Game);
+			inputSystem = new InputSystem(Game, ScreenSystem);
 			movementSystem = new MovementSystem();
-			physicsSystem = new PhysicsSystem(World.MaxNumEntities);
+			physicsSystem = new PhysicsSystem(world.MaxNumEntities);
 			cameraSystem = new CameraSystem();
 			aiSystem = new AISystem();
 			animationSystem = new AnimationSystem();
-
+			renderSystem = new RenderSystem(Game, graphicsManager);
 			spriteBatch = new SpriteBatch(Game.GraphicsDevice);
 			winScreen1 = Game.Content.Load<Texture2D>("Menu/winnerScreen1");
 			winScreen2 = Game.Content.Load<Texture2D>("Menu/winnerScreen2");
 			font = Game.Content.Load<SpriteFont>("Arial");
+
+			renderSystem.LoadContent();
+
 			fontPos = new Vector2(0, 0);
 		}
 

--- a/LegendOfCube/LegendOfCube/Screens/LevelSelectScreen.cs
+++ b/LegendOfCube/LegendOfCube/Screens/LevelSelectScreen.cs
@@ -2,17 +2,21 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using LegendOfCube.Engine;
+using Microsoft.Xna.Framework;
 
 namespace LegendOfCube.Screens
 {
 	class LevelSelectScreen : Screen
 	{
-		protected internal override void Update(Microsoft.Xna.Framework.GameTime gameTime, ScreenSystem switcher)
+		public LevelSelectScreen(Game game, ScreenSystem screenSystem) : base(game, screenSystem, false) {}
+
+		internal override void Update(GameTime gameTime)
 		{
 			throw new NotImplementedException();
 		}
 
-		protected internal override void Draw(Microsoft.Xna.Framework.GameTime gameTime, Engine.Graphics.RenderSystem renderSystem)
+		internal override void Draw(GameTime gameTime)
 		{
 			throw new NotImplementedException();
 		}

--- a/LegendOfCube/LegendOfCube/Screens/MenuItem.cs
+++ b/LegendOfCube/LegendOfCube/Screens/MenuItem.cs
@@ -9,49 +9,35 @@ namespace LegendOfCube.Screens
 { 
 	class MenuItem
 	{
-		private string text;
-		private Vector2 pos;
-		private bool selected;
 
-		public MenuItem(string text)
+		public MenuItem(string text, Rectangle rectangle, Action onClick)
 		{
-			this.text = text;
-			selected = false;
+			Text = text;
+			Rectangle = rectangle;
+			Selected = false;
+			OnClick = onClick;
 		}
 
-		public string Text
-		{
-			set {text = value;}
-			get {return text;}
-		}
+		public string Text { get; private set; }
 
-		public Vector2 Position
-		{
-			set {pos = value;}
-			get {return pos;}
-		}
+		public Rectangle Rectangle { get; private set; }
 
-		public bool Selected
-		{
-			set { selected = value; }
-			get { return selected; }
-		}
-
-		public void Update()
-		{
-
-		}
+		public bool Selected { get; set; }
+		public Action OnClick { get; private set; }
 
 		public void Draw(SpriteBatch spriteBatch, SpriteFont font)
 		{
-			Color color = selected ? Color.DarkOrange : Color.Black;
-			spriteBatch.DrawString(font, text, pos, color);
+			Color shadowColor = Color.Black;
+			Color color = Selected ? Color.DarkOrange : Color.White;
+			spriteBatch.DrawString(font, Text, new Vector2(Rectangle.Left + 1, Rectangle.Top + 1), shadowColor);
+			spriteBatch.DrawString(font, Text, new Vector2(Rectangle.Left, Rectangle.Top), color);
 		}
 
-		public void loadContent()
+		public void LoadContent()
 		{
 
 		}
 
 	}
+
 }

--- a/LegendOfCube/LegendOfCube/Screens/MenuScreen.cs
+++ b/LegendOfCube/LegendOfCube/Screens/MenuScreen.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using LegendOfCube.Engine;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace LegendOfCube.Screens
+{
+	abstract class MenuScreen : Screen
+	{
+		private readonly MenuInputSystem menuInputSystem;
+		private readonly List<MenuItem> menuItems;
+
+		private SpriteBatch spriteBatch;
+		private SpriteFont font;
+		private int selection;
+		private Vector2 nextItemPos = new Vector2(40, 40);
+
+		protected MenuScreen(Game game, ScreenSystem screenSystem) : base(game, screenSystem, false)
+		{
+			menuItems = new List<MenuItem>();
+			menuInputSystem = new MenuInputSystem(game, screenSystem);
+			selection = 0;
+		}
+
+		protected void AddMenuItem(MenuItem menuItem)
+		{
+			menuItems.Add(menuItem);
+			nextItemPos.X = menuItem.Rectangle.Left;
+			nextItemPos.Y = menuItem.Rectangle.Top + menuItem.Rectangle.Height;
+		}
+
+		protected void AddItemBelow(String text, Action onClick)
+		{
+			Vector2 size = font.MeasureString(text);
+			AddMenuItem(new MenuItem(text, new Rectangle((int)nextItemPos.X, (int)nextItemPos.Y, (int)size.X, (int)size.Y), onClick));
+		}
+
+		internal override void Update(GameTime gameTime)
+		{
+			menuInputSystem.ApplyInput(gameTime, menuItems, ref selection);
+		}
+
+		internal override void Draw(GameTime gameTime)
+		{
+			spriteBatch.Begin();
+			foreach (var menuItem in menuItems)
+			{
+				menuItem.Draw(spriteBatch, font);
+			}
+			spriteBatch.End();
+		}
+
+		internal override void LoadContent()
+		{
+			spriteBatch = new SpriteBatch(Game.GraphicsDevice);
+			font = Game.Content.Load<SpriteFont>("Arial");
+		}
+	}
+}

--- a/LegendOfCube/LegendOfCube/Screens/PauseScreen.cs
+++ b/LegendOfCube/LegendOfCube/Screens/PauseScreen.cs
@@ -7,97 +7,22 @@ namespace LegendOfCube.Screens
 {
 	class PauseScreen : MenuScreen
 	{
-		private readonly InputSystem inputSystem;
-		private readonly MenuInputSystem menuInputSystem;
-		private readonly CameraSystem cameraSystem;
-		private readonly ScreenSystem screenSystem;
-		private readonly Game game;
-		private SpriteBatch spriteBatch;
-		private SpriteFont font;
-
-		private Texture2D play;
-		private Texture2D exit;
-		private Texture2D levelSelect;
-		private Texture2D select;
-		private int selection;
-
-		public PauseScreen(Game game, ScreenSystem screenSystem) : base(game)
-		{
-			this.game = game;
-			this.screenSystem = screenSystem;
-			inputSystem = new InputSystem(game);
-			cameraSystem = new CameraSystem();
-			menuInputSystem = new MenuInputSystem(game);
-			selection = 0;
-		}
-
-		protected internal override void Update(GameTime gameTime, ScreenSystem switcher)
-		{
-			var world = screenSystem.GetCurrentWorld();
-
-			var delta = (float)gameTime.ElapsedGameTime.TotalSeconds;
-
-			inputSystem.ApplyInput(gameTime, world, switcher);
-			menuInputSystem.ApplyInput(gameTime, world, switcher, this, ref selection);
-			cameraSystem.OnUpdate(screenSystem.GetCurrentWorld(), delta);
-		}
-
-		protected internal override void Draw(GameTime gameTime, RenderSystem renderSystem)
-		{
-			var world = screenSystem.GetCurrentWorld();
-
-			Game.GraphicsDevice.Clear(Color.DarkTurquoise);
-
-			Game.GraphicsDevice.BlendState = BlendState.Opaque;
-			Game.GraphicsDevice.DepthStencilState = DepthStencilState.Default;
-			renderSystem.RenderWorld(world);
-
-			spriteBatch.Begin();
-			spriteBatch.Draw(play, new Vector2(100, 20), Color.Red);
-			spriteBatch.Draw(levelSelect, new Vector2(100, 110), Color.Red);
-			spriteBatch.Draw(exit, new Vector2(100, 200), Color.Red);
-
-			switch (selection)
-			{
-				case 0:
-					spriteBatch.Draw(select, new Vector2(35, 10), Color.Red);
-					break;
-				case 1:
-					spriteBatch.Draw(select, new Vector2(35, 100), Color.Red);
-					break;
-				case 2:
-					spriteBatch.Draw(select, new Vector2(35, 190), Color.Red);
-					break;
-
-			}
-			spriteBatch.End();
-		}
+		public PauseScreen(Game game, ScreenSystem screenSystem) : base(game, screenSystem) {}
 
 		internal override void LoadContent()
 		{
-			spriteBatch = new SpriteBatch(Game.GraphicsDevice);
-			font = Game.Content.Load<SpriteFont>("Arial");
-
-			play = Game.Content.Load<Texture2D>("Menu/play");
-			exit = Game.Content.Load<Texture2D>("Menu/exit");
-			levelSelect = Game.Content.Load<Texture2D>("Menu/level select");
-			select = Game.Content.Load<Texture2D>("Menu/selector");
-		}
-
-		internal override void PerformSelection()
-		{
-			switch (selection)
+			base.LoadContent();
+			AddItemBelow("Return to Game", () =>
+				ScreenSystem.RemoveCurrentScreen()
+			);
+			AddItemBelow("Main Menu", () =>
 			{
-				case 0:
-					screenSystem.SwitchScreen(Screens.ScreenTypes.GAME);
-					break;
-				case 1:
-					screenSystem.SwitchScreen(Screens.ScreenTypes.LEVEL_SELECT);
-					break;
-				case 2:
-					screenSystem.SwitchScreen(Screens.ScreenTypes.START);
-					break;
-			}
+				ScreenSystem.RemoveCurrentScreen();
+				ScreenSystem.RemoveCurrentScreen();
+			});
+			AddItemBelow("Exit Game", () =>
+				Game.Exit()
+			);
 		}
 	}
 }

--- a/LegendOfCube/LegendOfCube/Screens/Screen.cs
+++ b/LegendOfCube/LegendOfCube/Screens/Screen.cs
@@ -1,4 +1,5 @@
-﻿using LegendOfCube.Engine.Graphics;
+﻿using System;
+using LegendOfCube.Engine.Graphics;
 using Microsoft.Xna.Framework;
 using LegendOfCube.Engine;
 
@@ -6,33 +7,21 @@ namespace LegendOfCube.Screens
 {
 	public abstract class Screen
 	{
-		protected Game Game;
-		public World World;
+		protected Game Game { get; private set; }
+		protected ScreenSystem ScreenSystem { get; private set; }
+		public bool BackgroundRender { get; private set; }
 
-		protected Screen()
+		internal Screen(Game game, ScreenSystem screenSystem, bool backgroundRender)
 		{
-
-		}
-		protected Screen(Game game)
-		{
-			this.Game = game;
-		}
-
-		public void SetWorld(World world)
-		{
-			World = world;
+			Game = game;
+			ScreenSystem = screenSystem;
+			BackgroundRender = backgroundRender;
 		}
 
-		protected internal abstract void Update(GameTime gameTime, ScreenSystem switcher);
-		protected internal abstract void Draw(GameTime gameTime, RenderSystem renderSystem);
+		internal abstract void Update(GameTime gameTime);
+		internal abstract void Draw(GameTime gameTime);
+
 		internal abstract void LoadContent();
 	}
-	public abstract class MenuScreen : Screen
-	{
-		protected MenuScreen(Game game)
-		{
-			this.Game = game;
-		}
-		internal abstract void PerformSelection();
-	}
+
 }

--- a/LegendOfCube/LegendOfCube/Screens/StartScreen.cs
+++ b/LegendOfCube/LegendOfCube/Screens/StartScreen.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using LegendOfCube.Engine;
+using LegendOfCube.Levels;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
@@ -11,77 +12,26 @@ namespace LegendOfCube.Screens
 {
 	class StartScreen : MenuScreen
 	{
-		private readonly MenuInputSystem menuInputSystem;
-		private readonly ScreenSystem system;
-
-		private MenuItem[] items = new MenuItem[]{new MenuItem("Start Game"), new MenuItem("Change Level"), new MenuItem("Exit")};
-
-		private SpriteBatch spriteBatch;
-		private SpriteFont font;
-
-		private int selection;
-		
-
-		public StartScreen(Game game, ScreenSystem system) : base(game)
-		{
-			menuInputSystem = new MenuInputSystem(game);
-			this.Game = game;
-			this.system = system;
-
-			selection = 0;
-			items[0].Selected = true;
-			items[0].Position = new Vector2(25, 25);
-
-			items[1] = new MenuItem("Select Level");
-			items[1].Position = new Vector2(25, 40);
-
-			items[2] = new MenuItem("Exit");
-			items[2].Position = new Vector2(25, 55);
-
-		}
-		protected internal override void Update(Microsoft.Xna.Framework.GameTime gameTime, Screens.ScreenSystem switcher)
-		{
-			menuInputSystem.ApplyInput(gameTime, World, switcher, this, ref selection);
-			foreach(var item in items) 
-			{
-				item.Selected = false;
-			}
-			items[selection].Selected = true;
-		}
-
-		protected internal override void Draw(Microsoft.Xna.Framework.GameTime gameTime, Engine.Graphics.RenderSystem renderSystem)
-		{
-			Game.GraphicsDevice.Clear(Color.CornflowerBlue);
-			Game.GraphicsDevice.BlendState = BlendState.Opaque;
-			Game.GraphicsDevice.DepthStencilState = DepthStencilState.Default;
-
-			spriteBatch.Begin();
-			items[0].Draw(spriteBatch, font);
-			items[1].Draw(spriteBatch, font);
-			items[2].Draw(spriteBatch, font);
-			spriteBatch.End();	
-		}	
+		internal StartScreen(Game game, ScreenSystem screenSystem) : base(game, screenSystem) {}
 
 		internal override void LoadContent()
 		{
-			spriteBatch = new SpriteBatch(Game.GraphicsDevice);
-			font = Game.Content.Load<SpriteFont>("Arial");
-		}
+			base.LoadContent();
+			AddItemBelow("Start Game", () =>
+				ScreenSystem.AddGameScreen(LevelConstants.DEMO_LEVEL)
+			);
 
-		internal override void PerformSelection()
-		{
-			switch (selection)
-			{
-				case 0:
-					system.SwitchScreen(ScreenTypes.GAME);
-					break;
-				case 1:
-					system.SwitchScreen(ScreenTypes.LEVEL_SELECT);
-					break;
-				case 2:
-					Game.Exit();
-					break;
-			}
+			AddItemBelow("Select Level", () => 
+				ScreenSystem.AddScreen(new LevelSelectScreen(Game, ScreenSystem))
+			);
+
+			AddItemBelow("Options", () =>
+				{ }
+			);
+
+			AddItemBelow("Exit",
+				() => Game.Exit()
+			);
 		}
 	}
 }


### PR DESCRIPTION
Before merging this, merge pull request #50 first. This depends on that one.

Attempt at solving some problems with the screen architecture. For example, making new menus (looking like previous main menu) is now very easy. Making a simple level select screen should be pretty straightforward.
- Screens are sort of on a stack in ScreenSystem
- Generalized way to add menu items, need only text and action (lambda)
- Only GameScreen has a world (PauseScreen rendered on top of GameScreen instead)
- RenderSystem is created for each new GameScreen
- GameScreen takes a Level (which isn't a created world, it has
  Level.CreateWorld())
- Can go back to main menu from pause menu
- Pause menu now looks boring
